### PR TITLE
feat: Build multi-arch (linux/amd64 + linux/arm64) container images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         env:
           REGISTRY: ${{ secrets.REGISTRY }}
           VERSION: ${{ steps.meta.outputs.version }}
-          PLATFORM: linux/amd64
+          PLATFORM: linux/amd64,linux/arm64
           EXTRA_TAGS: -t ${{ secrets.REGISTRY }}/browser-ui:latest
         run: |
           make deploy
@@ -96,4 +96,4 @@ jobs:
         run: |
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
-            --generate-notes          
+            --generate-notes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS ui-builder
+FROM --platform=$BUILDPLATFORM node:22-alpine AS ui-builder
 ARG VERSION=develop
 ENV VERSION=$VERSION
 WORKDIR /src
@@ -7,13 +7,14 @@ RUN npm ci --prefix ./src
 COPY src/ ./src/
 RUN npm run build --prefix ./src
 
-FROM golang:1.25.0 AS go-builder
+FROM --platform=$BUILDPLATFORM golang:1.25.0 AS go-builder
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
-RUN go build -trimpath -ldflags="-s -w" -o /out/browser-ui ./cmd/browser-ui
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o /out/browser-ui ./cmd/browser-ui
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /app


### PR DESCRIPTION
Cross-compile the Go binary via BuildKit: pin the builder stage to $BUILDPLATFORM and pass the auto-provided TARGETOS/TARGETARCH to `go build` (GOOS/GOARCH), dropping the hardcoded GOARCH=amd64.

CI now builds linux/amd64,linux/arm64.

Related to https://github.com/alcounit/selenosis/issues/77

(Also removes trailing whitespace in `ci.yml`)